### PR TITLE
Auto-generate missing modules on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ ollama pull llama2
 ```
 
 > **Note**: The model name must match the one set in `settings.py`.
+> The first run of `python main.py` automatically creates any missing local
+> directories (like `logs/`) and stub modules such as `messages/`.
 
 ---
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+REQUIRED_DIRS = [
+    'logs',
+    'history',
+]
+
+REQUIRED_FILES = {
+    'messages/__init__.py': (
+        "processing_lock_message = 'Por favor espera mientras se procesa tu mensaje anterior...\n'"
+    ),
+    'history/__init__.py': '',
+}
+
+
+def ensure_required_files(base_path: str = '.') -> None:
+    """Create required directories and files if they don't exist."""
+    base = Path(base_path)
+
+    for directory in REQUIRED_DIRS:
+        dir_path = base / directory
+        if not dir_path.exists():
+            dir_path.mkdir(parents=True, exist_ok=True)
+            print(f'[bootstrap] Created directory: {dir_path}')
+
+    for file_path, content in REQUIRED_FILES.items():
+        path = base / file_path
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding='utf-8')
+            print(f'[bootstrap] Created file: {path}')
+

--- a/main.py
+++ b/main.py
@@ -39,8 +39,10 @@ from config_loader import (
     load_telegram_token,
     load_ai_prompt,
     load_whitelist,
-    load_keyword_phrases
+    load_keyword_phrases,
 )
+import bootstrap
+bootstrap.ensure_required_files()
 from messages import processing_lock_message
 from config_loader import load_chroma_client
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import bootstrap
+
+
+def test_ensure_required_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    bootstrap.ensure_required_files()
+
+    for directory in bootstrap.REQUIRED_DIRS:
+        assert (tmp_path / directory).is_dir()
+
+    for file_path in bootstrap.REQUIRED_FILES:
+        assert (tmp_path / file_path).is_file()


### PR DESCRIPTION
## Summary
- provide `bootstrap` module to create gitignored folders
- call bootstrap when main starts
- add pytest for bootstrap
- document auto-generation behavior in README

## Testing
- `pytest -q`

Fixes #1 

------
https://chatgpt.com/codex/tasks/task_e_68562c7beedc832e8504f7cac365deaf